### PR TITLE
Fix: Build fails due to `std::numeric_limits` ...

### DIFF
--- a/BrotBoxEngine/BBE/List.h
+++ b/BrotBoxEngine/BBE/List.h
@@ -10,6 +10,7 @@
 #include <initializer_list>
 #include <iostream>
 #include <cstring>
+#include <limits>
 
 namespace bbe
 {


### PR DESCRIPTION
... being undefined on GCC 11.1.0 and libstdc++. I suppose some other standard library header removed an `#include <limits>`.