### PR TITLE
Add macOS Support for OpenGL Core Profile Compatibility

### DIFF
--- a/BrotBoxEngine/Window.cpp
+++ b/BrotBoxEngine/Window.cpp
@@ -73,6 +73,12 @@ bbe::Window::Window(int width, int height, const char* title, bbe::Game* game, u
 #ifdef BBE_RENDERER_OPENGL
 	glfwWrapper::glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
 	glfwWrapper::glfwWindowHint(GLFW_SAMPLES, 4);
+#ifdef __APPLE__
+	glfwWrapper::glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+	glfwWrapper::glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+	glfwWrapper::glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+	glfwWrapper::glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+#endif
 #endif
 	//glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 #ifndef __EMSCRIPTEN__


### PR DESCRIPTION
**Description:**
This PR introduces modifications to enable macOS compatibility by ensuring compliance with OpenGL Core Profile requirements. Key updates include:

**Changes Made:**

(All changes are wrapped in `#ifdef __APPLE__` to maintain compatibility with Windows and other platforms.)

1. **Platform-Specific Compatibility for Context Initialization:**
 - Added `glfwWindowHint` settings to enforce an OpenGL Core Profile context on macOS
 - Ensures macOS uses the correct OpenGL version and profile.

2. **Shader Version Update for macOS:**
 - Updated GLSL shader version `#version 330 core` to be compatible with macOS Core Profile

3. **VAO Usage Across Key OpenGL Functions:**
 - Added VAO creation, binding, and management in the draw functions to ensure compatibility with macOS Core Profile:

**Next Steps:**
- Plan to add Vulkan support for macOS

**System Information:**
- **Operating System**: macOS Sequoia 15
- **System Architecture**: ARM64 (Apple Silicon M2)
- **C++ Compiler**: LLVM clang 19.1.2 (Homebrew)

Please review the changes and provide feedback. Looking forward to merging these updates to add proper OpenGL support for macOS!


   
